### PR TITLE
Added ability to update room and device config from LightWaveRF Host servers

### DIFF
--- a/bin/lightwaverf
+++ b/bin/lightwaverf
@@ -9,6 +9,8 @@ case ARGV[0]
     puts LightWaveRF.new.energy ARGV[1], ARGV[2], ARGV[3]
   when 'timer'
     puts LightWaveRF.new.timer ARGV[1], ARGV[2]
+  when 'update'
+    puts LightWaveRF.new.update_config ARGV[1], ARGV[2]
   else
     LightWaveRF.new.send ARGV[0], ARGV[1], ARGV[2], ARGV[3]
 end

--- a/lightwaverf.gemspec
+++ b/lightwaverf.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |s|
   s.name        = 'lightwaverf'
-  s.version     = '0.3.0'
+  s.version     = '0.3.1'
   s.date        = Time.now.strftime '%Y-%m-%d'
   s.summary     = 'Home automation'
   s.description = 'Interact with lightwaverf wifi link from code or the command line. Control your lights, heating, sockets etc. Also set up timers using a google calendar and log energy usage.'
-  s.authors     = [ 'Paul Clarke' ]
+  s.authors     = [ 'Paul Clarke', 'Ian Perrin' ]
   s.email       = 'pauly@clarkeology.com'
   s.files       = [ 'lib/lightwaverf.rb' ]
   s.homepage    = 'http://www.clarkeology.com/wiki/lightwaverf+ruby'


### PR DESCRIPTION
Hi @pauly

I've made a few additions to the gem so that it 
1. Sends a neater(?) message to the WiFi link and shows the response from the WiFi Link when using the send method in debug mode (see 25f2a35). This change was rather cosmetic and the result of some simple tests I performed to ensure I could build (and modify) the gem from your source!
2. Can update the rooms and devices in the config file directly from the LightWaveRF Host servers (see 7db7c40) via a new update_config method which can be called with the email address and pin credentials for the https://lightwaverfhost.co.uk/manager/index.php. e.g.:
   
   ```
   LightWaveRF.new.update_config 'name@example.com', '1234'
   LightWaveRF.new.update_config 'name@example.com', '1234', true
   lightwaverf update 'name@example.com', '1234'
   ```

It would be great to add this to the core and get the new version pushed to rubygems.org so I can take advantage of it in the Siri Proxy plugin.

Keep up the good work

Ian
